### PR TITLE
Skip conditional validations

### DIFF
--- a/lib/nullalign/introspectors/validates_presence_of.rb
+++ b/lib/nullalign/introspectors/validates_presence_of.rb
@@ -5,7 +5,7 @@ module Nullalign
     class ValidatesPresenceOf
       def instances(model)
         model.validators.select do |v|
-          v.class == ActiveRecord::Validations::PresenceValidator
+          v.class == ActiveRecord::Validations::PresenceValidator && (v.options.keys & %i(on if unless)).empty?
         end
       end
 


### PR DESCRIPTION
Conditional presence validations are not necessarily backed by database constraints, but are enforced only at the application layer. Skipping checks on those validations would reduce false-positives.

Or, are you more inclined to disable checks on such columns through other means? (e.g., column comments, configurations)